### PR TITLE
[JWT 미들웨어]JWT미들웨어 클래스를 통한 토큰 인증 및 사용자 정보 확인

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,5 +1,11 @@
+import { JwtMiddleware } from './jwt/jwt.middleware';
 import { User } from './users/entities/user.entity';
-import { Module } from '@nestjs/common';
+import {
+  Module,
+  NestModule,
+  MiddlewareConsumer,
+  RequestMethod,
+} from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
@@ -38,6 +44,7 @@ import * as Joi from 'joi';
     }),
     GraphQLModule.forRoot({
       autoSchemaFile: true,
+      context: ({ req }) => ({ user: req['user'] }),
     }),
     UsersModule,
     CommonModule,
@@ -48,4 +55,11 @@ import * as Joi from 'joi';
   controllers: [],
   providers: [],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(JwtMiddleware).forRoutes({
+      path: '/graphql',
+      method: RequestMethod.ALL,
+    });
+  }
+}

--- a/src/jwt/jwt.middleware.ts
+++ b/src/jwt/jwt.middleware.ts
@@ -1,0 +1,28 @@
+import { UsersService } from './../users/users.service';
+import { JwtService } from './jwt.service';
+import { NestMiddleware, Injectable } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class JwtMiddleware implements NestMiddleware {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly userService: UsersService,
+  ) {}
+  async use(req: Request, res: Response, next: NextFunction) {
+    if ('x-jwt' in req.headers) {
+      const token = req.headers['x-jwt'];
+      const decoded = this.jwtService.verify(token.toString());
+
+      if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
+        try {
+          const user = await this.userService.findById(decoded['id']);
+          req['user'] = user;
+        } catch (error) {
+          console.log(error);
+        }
+      }
+    }
+    next();
+  }
+}

--- a/src/jwt/jwt.service.ts
+++ b/src/jwt/jwt.service.ts
@@ -8,7 +8,12 @@ export class JwtService {
   constructor(
     @Inject(CONFIG_OPTIONS) private readonly options: JwtModuleOptions,
   ) {}
+
   sign(userId: number): string {
     return jwt.sign({ id: userId }, this.options.secretKey);
+  }
+
+  verify(token: string) {
+    return jwt.verify(token, this.options.secretKey);
   }
 }

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -7,5 +7,6 @@ import { Module } from '@nestjs/common';
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UserResolver, UsersService],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -5,7 +5,7 @@ import {
 } from './dtos/create-account.dto';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
-import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
 
 @Resolver(() => User)
 export class UserResolver {
@@ -14,6 +14,16 @@ export class UserResolver {
   @Query(() => Boolean)
   hi() {
     return true;
+  }
+
+  @Query(() => User)
+  me(@Context() context) {
+    if (!context.user) {
+      return;
+    } else {
+      console.log(context.user);
+      return context.user;
+    }
   }
 
   @Mutation(() => CreateAccountOutput)

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -68,4 +68,8 @@ export class UsersService {
       };
     }
   }
+
+  async findById(id: number): Promise<User> {
+    return this.users.findOne({ id });
+  }
 }


### PR DESCRIPTION
`JwtMiddleware`를 통해 클라이언트에서 받은 토큰을 인증하고, `req`에 유저 필드를 만들어서 `graphql context`에 넘겨준다. 이를 통해 유저 `resolver`에서 `@Context` 데코레이터를 통해  컨텍스트를 받아와서 유저 정보를 획득할 수 있다. 

app 모듈에서 `imports`하고 있는 그래프큐엘 모듈의 설정에 `context`를 추가하고 req를 받아올 수 있다. `context`에 등록된 함수는 리퀘스트가 발생할 떄마다 실행된다. 따라서 미들웨어를 통해 검증된 토큰의 유저 정보가 context로 들어올 수 있는 것이다. 

```
    GraphQLModule.forRoot({
      autoSchemaFile: true,
      context: ({ req }) => ({ user: req['user'] }),
    }),
```