### PR TITLE
[Auth] 토큰 인증을 위한 가드 적용

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,6 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from './users/users.module';
-import { CommonModule } from './common/common.module';
 import { JwtModule } from './jwt/jwt.module';
 import * as Joi from 'joi';
 @Module({
@@ -47,7 +46,6 @@ import * as Joi from 'joi';
       context: ({ req }) => ({ user: req['user'] }),
     }),
     UsersModule,
-    CommonModule,
     JwtModule.forRoot({
       secretKey: process.env.SECRET_KEY,
     }),

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,0 +1,15 @@
+import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
+import { GqlExecutionContext } from '@nestjs/graphql';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext) {
+    const gqlContext = GqlExecutionContext.create(context).getContext();
+    const user = gqlContext['user'];
+    console.log('this is my user', user);
+    if (!user) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class AuthModule {}

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,3 +1,4 @@
+import { AuthGuard } from './../auth/auth.guard';
 import { LoginOutput, LoginInput } from './dtos/login.dto';
 import {
   CreateAccountInput,
@@ -6,7 +7,7 @@ import {
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
 import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
-
+import { UseGuards } from '@nestjs/common';
 @Resolver(() => User)
 export class UserResolver {
   constructor(private readonly usersService: UsersService) {}
@@ -17,14 +18,8 @@ export class UserResolver {
   }
 
   @Query(() => User)
-  me(@Context() context) {
-    if (!context.user) {
-      return;
-    } else {
-      console.log(context.user);
-      return context.user;
-    }
-  }
+  @UseGuards(AuthGuard)
+  me(@Context() context) {}
 
   @Mutation(() => CreateAccountOutput)
   async createAccount(


### PR DESCRIPTION
`AuthGuard` 클래스를 통해 http 요청이 들어오기 전에 유효성을 검사해서 진행 여부를 결정할 수 있다. `graphql`에 사용하기 위해서, http 요청을 `GqlExecutionContext` 메서드를 통해 그래프큐엘 컨텍스트로 변환했다.  이를 통해 유저 정보를 얻을 수 있다. 

가드 클래스를 적용하기 위해서는 해당 리졸버로 가서 `@UseGuards()` 데코레이터를 사용해서 인자로 해당 가드 클래스를 넘겨주면 된다.