### PR TITLE
[EditProfile] 유저 정보 수정 기능 구현

### DIFF
--- a/src/common/dtos/output.dto.ts
+++ b/src/common/dtos/output.dto.ts
@@ -1,7 +1,7 @@
 import { Field, ObjectType } from '@nestjs/graphql';
 
 @ObjectType()
-export class MutationOutput {
+export class CoreOutput {
   @Field(() => String, { nullable: true })
   error?: string;
 

--- a/src/common/entities/core.entity.ts
+++ b/src/common/entities/core.entity.ts
@@ -4,8 +4,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
-import { Field } from '@nestjs/graphql';
-
+import { Field, ObjectType } from '@nestjs/graphql';
+@ObjectType()
 export class CoreEntity {
   @PrimaryGeneratedColumn()
   @Field(() => Number)

--- a/src/users/dtos/create-account.dto.ts
+++ b/src/users/dtos/create-account.dto.ts
@@ -1,4 +1,4 @@
-import { MutationOutput } from './../../common/dtos/output.dto';
+import { CoreOutput } from './../../common/dtos/output.dto';
 import { User } from './../entities/user.entity';
 import { InputType, PickType, ObjectType } from '@nestjs/graphql';
 
@@ -10,4 +10,4 @@ export class CreateAccountInput extends PickType(User, [
 ]) {}
 
 @ObjectType()
-export class CreateAccountOutput extends MutationOutput {}
+export class CreateAccountOutput extends CoreOutput {}

--- a/src/users/dtos/edit-profile.dto.ts
+++ b/src/users/dtos/edit-profile.dto.ts
@@ -1,0 +1,11 @@
+import { User } from './../entities/user.entity';
+import { ObjectType, PickType, PartialType, InputType } from '@nestjs/graphql';
+import { CoreOutput } from './../../common/dtos/output.dto';
+
+@ObjectType()
+export class EditProfileOutput extends CoreOutput {}
+
+@InputType()
+export class EditProfileInput extends PartialType(
+  PickType(User, ['email', 'password']),
+) {}

--- a/src/users/dtos/login.dto.ts
+++ b/src/users/dtos/login.dto.ts
@@ -1,12 +1,12 @@
 import { User } from './../entities/user.entity';
-import { MutationOutput } from './../../common/dtos/output.dto';
+import { CoreOutput } from './../../common/dtos/output.dto';
 import { InputType, PickType, ObjectType, Field } from '@nestjs/graphql';
 
 @InputType()
 export class LoginInput extends PickType(User, ['email', 'password']) {}
 
 @ObjectType()
-export class LoginOutput extends MutationOutput {
+export class LoginOutput extends CoreOutput {
   @Field(() => String, { nullable: true })
   token?: string;
 }

--- a/src/users/dtos/user-profile.dto.ts
+++ b/src/users/dtos/user-profile.dto.ts
@@ -1,0 +1,15 @@
+import { User } from './../entities/user.entity';
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
+
+@ArgsType()
+export class UserProfileInput {
+  @Field(() => Number)
+  userId: number;
+}
+
+@ObjectType()
+export class UserProfileOutput extends CoreOutput {
+  @Field(() => User, { nullable: true })
+  user?: User;
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -5,7 +5,7 @@ import {
   registerEnumType,
 } from '@nestjs/graphql';
 import { CoreEntity } from './../../common/entities/core.entity';
-import { Entity, Column, BeforeInsert } from 'typeorm';
+import { Entity, Column, BeforeInsert, BeforeUpdate } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { InternalServerErrorException } from '@nestjs/common';
 import { IsEmail, IsString, IsEnum } from 'class-validator';
@@ -36,6 +36,7 @@ export class User extends CoreEntity {
   role: UserRole;
 
   @BeforeInsert()
+  @BeforeUpdate()
   async hashPassword(): Promise<void> {
     try {
       this.password = await bcrypt.hash(this.password, 10);

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,3 +1,5 @@
+import { EditProfileOutput, EditProfileInput } from './dtos/edit-profile.dto';
+import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
 import { AuthGuard } from './../auth/auth.guard';
 import { LoginOutput, LoginInput } from './dtos/login.dto';
@@ -7,21 +9,36 @@ import {
 } from './dtos/create-account.dto';
 import { UsersService } from './users.service';
 import { User } from './entities/user.entity';
-import { Resolver, Query, Mutation, Args, Context } from '@nestjs/graphql';
+import { Resolver, Query, Mutation, Args } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
 @Resolver(() => User)
 export class UserResolver {
   constructor(private readonly usersService: UsersService) {}
 
-  @Query(() => Boolean)
-  hi() {
-    return true;
-  }
-
   @Query(() => User)
   @UseGuards(AuthGuard)
   me(@AuthUser() authUser: User) {
     return authUser;
+  }
+
+  @UseGuards(AuthGuard)
+  @Query(() => UserProfileOutput)
+  async userProfile(
+    @Args() userProfileInput: UserProfileInput,
+  ): Promise<UserProfileOutput> {
+    try {
+      const user = await this.usersService.findById(userProfileInput.userId);
+      if (!user) throw Error();
+      return {
+        isSucceeded: true,
+        user,
+      };
+    } catch (error) {
+      return {
+        error: 'User Not Found',
+        isSucceeded: false,
+      };
+    }
   }
 
   @Mutation(() => CreateAccountOutput)
@@ -34,5 +51,24 @@ export class UserResolver {
   @Mutation(() => LoginOutput)
   async login(@Args('input') loginInput: LoginInput): Promise<LoginOutput> {
     return this.usersService.login(loginInput);
+  }
+
+  @UseGuards(AuthGuard)
+  @Mutation(() => EditProfileOutput)
+  async editProfile(
+    @AuthUser() authUser: User,
+    @Args('input') editProfileInput: EditProfileInput,
+  ): Promise<EditProfileOutput> {
+    try {
+      await this.usersService.editProfile(authUser.id, editProfileInput);
+      return {
+        isSucceeded: true,
+      };
+    } catch (error) {
+      return {
+        isSucceeded: false,
+        error,
+      };
+    }
   }
 }

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,3 +1,4 @@
+import { EditProfileInput } from './dtos/edit-profile.dto';
 import { JwtService } from './../jwt/jwt.service';
 import { LoginInput, LoginOutput } from './dtos/login.dto';
 import {
@@ -71,5 +72,19 @@ export class UsersService {
 
   async findById(id: number): Promise<User> {
     return this.users.findOne({ id });
+  }
+
+  async editProfile(
+    userId: number,
+    { email, password }: EditProfileInput,
+  ): Promise<User> {
+    const user = await this.users.findOne(userId);
+    if (email) {
+      user.email = email;
+    }
+    if (password) {
+      user.password = password;
+    }
+    return this.users.save(user);
   }
 }


### PR DESCRIPTION
EditProfile 기능을 구현하기 위해 UserRepository에서 유저를 받아와서 update 프로퍼티를 사용하고자 했다. update 메서드는 db에 `Entity`가 있는지 유무를 확인하지 않는 대신 가장 빠르고 효율적인 방법이다. 정보 수정은 이미 로그인한 유저만 수행할 수 있다고 가정하기 때문에 바로 업데이트를 수행하고자 했다. 

그러나 비밀번호를 변경하는 경우에는 Entity에 걸어두었던 `@BeforeInsert` 데코레이터가 실행되지 않으므로, `@BeforeUpdate()`데코레이터를 사용하고자 하였으나 update 메서드가 db에 수정 쿼리를 날리기만 할 뿐, `Entity`를 수정해주지는 않았기 때문에 호출되지 않았다. 

이를 해결하기 위해 다시 save 메서드를 사용했다. save 메서드는 엔티티가 db에 없으면 생성시켜주지만, 기존 엔티티가 존재하는 경우, 엔티티를 수정해준다.