### PR TITLE
[verifyEmail]이메일 인증 엔티티 추가 및 이메일 인증 로직 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "rimraf": "^3.0.2",
         "rxjs": "^6.6.3",
         "typeorm": "^0.2.31",
-        "typeorm-naming-strategies": "^2.0.0"
+        "typeorm-naming-strategies": "^2.0.0",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@nestjs/cli": "^7.5.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "rimraf": "^3.0.2",
     "rxjs": "^6.6.3",
     "typeorm": "^0.2.31",
-    "typeorm-naming-strategies": "^2.0.0"
+    "typeorm-naming-strategies": "^2.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@nestjs/cli": "^7.5.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { Verification } from './users/entities/verification.entity';
 import { JwtMiddleware } from './jwt/jwt.middleware';
 import { User } from './users/entities/user.entity';
 import {
@@ -39,7 +40,7 @@ import * as Joi from 'joi';
       synchronize: process.env.NODE_ENV !== 'prod',
       logging: process.env.NODE_ENV !== 'prod',
       namingStrategy: new SnakeNamingStrategy(),
-      entities: [User],
+      entities: [User, Verification],
     }),
     GraphQLModule.forRoot({
       autoSchemaFile: true,

--- a/src/users/dtos/verify-email.dto.ts
+++ b/src/users/dtos/verify-email.dto.ts
@@ -1,0 +1,9 @@
+import { Verification } from './../entities/verification.entity';
+import { ObjectType, PickType, InputType } from '@nestjs/graphql';
+import { CoreOutput } from './../../common/dtos/output.dto';
+
+@ObjectType()
+export class VerifyEmailOutput extends CoreOutput {}
+
+@InputType()
+export class VerifyEmailInput extends PickType(Verification, ['code']) {}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -25,7 +25,7 @@ export class User extends CoreEntity {
   @IsEmail()
   email: string;
 
-  @Column()
+  @Column({ select: false })
   @Field(() => String)
   @IsString()
   password: string;
@@ -35,14 +35,20 @@ export class User extends CoreEntity {
   @IsEnum(UserRole)
   role: UserRole;
 
+  @Column({ default: false })
+  @Field(() => Boolean)
+  verified: boolean;
+
   @BeforeInsert()
   @BeforeUpdate()
   async hashPassword(): Promise<void> {
-    try {
-      this.password = await bcrypt.hash(this.password, 10);
-    } catch (error) {
-      console.log(error);
-      throw new InternalServerErrorException();
+    if (this.password) {
+      try {
+        this.password = await bcrypt.hash(this.password, 10);
+      } catch (error) {
+        console.log(error);
+        throw new InternalServerErrorException();
+      }
     }
   }
 

--- a/src/users/entities/verification.entity.ts
+++ b/src/users/entities/verification.entity.ts
@@ -1,0 +1,23 @@
+import { v4 as uuidv4 } from 'uuid';
+import { User } from './user.entity';
+import { CoreEntity } from './../../common/entities/core.entity';
+import { Entity, Column, OneToOne, JoinColumn, BeforeInsert } from 'typeorm';
+import { InputType, ObjectType, Field } from '@nestjs/graphql';
+
+@InputType({ isAbstract: true })
+@ObjectType()
+@Entity()
+export class Verification extends CoreEntity {
+  @Column()
+  @Field(() => String)
+  code: string;
+
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  user: User;
+
+  @BeforeInsert()
+  createCode(): void {
+    this.code = uuidv4();
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,3 +1,4 @@
+import { Verification } from './entities/verification.entity';
 import { UsersService } from './users.service';
 import { UserResolver } from './users.resolver';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -5,7 +6,7 @@ import { User } from './entities/user.entity';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, Verification])],
   providers: [UserResolver, UsersService],
   exports: [UsersService],
 })

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,3 +1,4 @@
+import { VerifyEmailInput, VerifyEmailOutput } from './dtos/verify-email.dto';
 import { EditProfileOutput, EditProfileInput } from './dtos/edit-profile.dto';
 import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
@@ -61,6 +62,23 @@ export class UserResolver {
   ): Promise<EditProfileOutput> {
     try {
       await this.usersService.editProfile(authUser.id, editProfileInput);
+      return {
+        isSucceeded: true,
+      };
+    } catch (error) {
+      return {
+        isSucceeded: false,
+        error,
+      };
+    }
+  }
+
+  @Mutation(() => VerifyEmailOutput)
+  async verifyEmail(
+    @Args('input') { code }: VerifyEmailInput,
+  ): Promise<VerifyEmailOutput> {
+    try {
+      await this.usersService.verifyEmail(code);
       return {
         isSucceeded: true,
       };


### PR DESCRIPTION
`verification` 엔티티를 추가하여, `user`엔티티와 1대1 관계를 맺는다. 이메일 인증 여부를 확인할 수 있으며, uuid를 통해 인증 코드를 생성한다. 