### PR TITLE
[test]메일 서비스 클래스 테스트 유닛 테스트

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    "@typescript-eslint/no-empty-function": 'off'
   },
 };

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -1,0 +1,59 @@
+import { CONFIG_OPTIONS } from './../common/common.constants';
+import { Test } from '@nestjs/testing';
+import { MailService } from './mail.service';
+
+jest.mock('got');
+
+describe('MailService', () => {
+  let service: MailService;
+
+  beforeEach(async () => {
+    const module = await Test.createTestingModule({
+      providers: [
+        MailService,
+        {
+          provide: CONFIG_OPTIONS,
+          useValue: {
+            apiKey: 'test-key',
+            domain: 'test-domain',
+            fromEmail: 'test-fromEmail',
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<MailService>(MailService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('sendVerificationEmail', () => {
+    it('should call sendEmail', () => {
+      const sendEmailSpy = jest
+        .spyOn(MailService.prototype as any, 'sendEmail')
+        .mockImplementation(async () => {});
+
+      const sendVerificationEmailArgs = {
+        email: 'email',
+        code: 'code',
+      };
+
+      service.sendVerificationEmail(
+        sendVerificationEmailArgs.email,
+        sendVerificationEmailArgs.code,
+      );
+
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendEmailSpy).toHaveBeenCalledWith(
+        'Verify your email',
+        'confrim-email',
+        [
+          { key: 'code', value: sendVerificationEmailArgs.code },
+          { key: 'username', value: sendVerificationEmailArgs.email },
+        ],
+      );
+    });
+  });
+});


### PR DESCRIPTION
`sendEmail` 메서드는 `private`메서드로서 `sendVerificationEmail` 메서드 내부에서 호출되어 테스트 되었기 때문에, 따로 테스트 하지 않음. `private` 메서드를 유닛 테스트 해야 되는가에 대한 의문이 남아있음.