### PR TITLE
[Auth]유저의 Role에 기반한 요청 권한 설정

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { AuthModule } from './auth/auth.module';
 import { RestaurantsModule } from './restaurants/restaurants.module';
 import { Category } from './restaurants/entities/category.entity';
 import { Restaurant } from './restaurants/entities/restaurant.entity';
@@ -64,6 +65,7 @@ import * as Joi from 'joi';
     }),
     UsersModule,
     RestaurantsModule,
+    AuthModule,
   ],
   controllers: [],
   providers: [],

--- a/src/auth/auth.guard.ts
+++ b/src/auth/auth.guard.ts
@@ -1,14 +1,27 @@
+import { User } from './../users/entities/user.entity';
+import { allowedRoles } from './role.decorator';
 import { Injectable, CanActivate, ExecutionContext } from '@nestjs/common';
 import { GqlExecutionContext } from '@nestjs/graphql';
+import { Reflector } from '@nestjs/core';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
   canActivate(context: ExecutionContext) {
+    const roles = this.reflector.get<allowedRoles>(
+      'roles',
+      context.getHandler(),
+    );
+    if (!roles) {
+      return true;
+    }
+
     const gqlContext = GqlExecutionContext.create(context).getContext();
-    const user = gqlContext['user'];
+    const user: User = gqlContext['user'];
     if (!user) {
       return false;
     }
-    return true;
+
+    return roles.includes('Any') || roles.includes(user.role);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,12 @@
+import { AuthGuard } from './auth.guard';
 import { Module } from '@nestjs/common';
-
-@Module({})
+import { APP_GUARD } from '@nestjs/core';
+@Module({
+  providers: [
+    {
+      provide: APP_GUARD,
+      useClass: AuthGuard,
+    },
+  ],
+})
 export class AuthModule {}

--- a/src/auth/role.decorator.ts
+++ b/src/auth/role.decorator.ts
@@ -1,0 +1,6 @@
+import { UserRole } from './../users/entities/user.entity';
+import { SetMetadata } from '@nestjs/common';
+
+export type allowedRoles = keyof typeof UserRole | 'Any';
+
+export const Role = (roles: allowedRoles[]) => SetMetadata('roles', roles);

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -33,6 +33,6 @@ export class Restaurant extends CoreEntity {
   category: Category;
 
   @Field(() => User)
-  @ManyToOne(() => User, (user) => user.restaurants)
+  @ManyToOne(() => User, (user) => user.restaurants, { onDelete: 'CASCADE' })
   owner: User;
 }

--- a/src/restaurants/restaurants.resolver.ts
+++ b/src/restaurants/restaurants.resolver.ts
@@ -1,5 +1,5 @@
-import { UseGuards } from '@nestjs/common';
-import { User } from './../users/entities/user.entity';
+import { Role } from './../auth/role.decorator';
+import { User, UserRole } from './../users/entities/user.entity';
 import { AuthUser } from './../auth/auth-user.decorator';
 import { RestaurantService } from './restaurants.service';
 import {
@@ -14,6 +14,7 @@ export class RestaurantResolver {
   constructor(private readonly restaurantService: RestaurantService) {}
 
   @Mutation(() => CreateRestaurantOutput)
+  @Role(['OWNER'])
   async createRestaurant(
     @AuthUser() authUser: User,
     @Args('input') createRestaurantInput: CreateRestaurantInput,

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -10,10 +10,11 @@ import { Entity, Column, BeforeInsert, BeforeUpdate, OneToMany } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 import { InternalServerErrorException } from '@nestjs/common';
 import { IsEmail, IsString, IsEnum, IsBoolean } from 'class-validator';
+
 export enum UserRole {
-  Client,
-  Owner,
-  Delivery,
+  CLIENT = 'CLIENT',
+  OWNER = 'OWNER',
+  DELIVERY = 'DELIVERY',
 }
 
 registerEnumType(UserRole, { name: 'UserRole' });

--- a/src/users/users.resolver.ts
+++ b/src/users/users.resolver.ts
@@ -1,3 +1,4 @@
+import { Role } from './../auth/role.decorator';
 import { VerifyEmailInput, VerifyEmailOutput } from './dtos/verify-email.dto';
 import { EditProfileOutput, EditProfileInput } from './dtos/edit-profile.dto';
 import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
@@ -17,12 +18,12 @@ export class UserResolver {
   constructor(private readonly usersService: UsersService) {}
 
   @Query(() => User)
-  @UseGuards(AuthGuard)
+  @Role(['Any'])
   me(@AuthUser() authUser: User) {
     return authUser;
   }
 
-  @UseGuards(AuthGuard)
+  @Role(['Any'])
   @Query(() => UserProfileOutput)
   async userProfile(
     @Args() userProfileInput: UserProfileInput,
@@ -42,7 +43,7 @@ export class UserResolver {
     return this.usersService.login(loginInput);
   }
 
-  @UseGuards(AuthGuard)
+  @Role(['Any'])
   @Mutation(() => EditProfileOutput)
   async editProfile(
     @AuthUser() authUser: User,


### PR DESCRIPTION
`Role` 데코레이터를 만들어서 각 쿼리와 뮤테이션 상단에 role 별로 허용되는 요청을 설정한다. 
`AuthGuard`에서 해당 role을 검사하여 접근을 제한할 수 있다. 

현재는 `authModule`에서 'APP_GUARD'라는 상수를 사용하여 전체 요청에 대해 가드가 적용되도록 하였으므로, `Role` 데코레이터가 없는 리졸버는 `public` 리졸버로 간주한다. 