### PR TITLE
[Orders]Orders 모듈 생성 및 order 엔티티 생성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { Order } from './orders/entities/order.entity';
 import { Dish } from './restaurants/entities/dish.entity';
 import { AuthModule } from './auth/auth.module';
 import { RestaurantsModule } from './restaurants/restaurants.module';
@@ -19,6 +20,7 @@ import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from './users/users.module';
 import { JwtModule } from './jwt/jwt.module';
 import { MailModule } from './mail/mail.module';
+import { OrdersModule } from './orders/orders.module';
 import * as Joi from 'joi';
 @Module({
   imports: [
@@ -50,7 +52,7 @@ import * as Joi from 'joi';
       // logging:
       //   process.env.NODE_ENV !== 'prod' && process.env.NODE_ENV !== 'test',
       namingStrategy: new SnakeNamingStrategy(),
-      entities: [User, Verification, Restaurant, Category, Dish],
+      entities: [User, Verification, Restaurant, Category, Dish, Order],
     }),
     GraphQLModule.forRoot({
       autoSchemaFile: true,
@@ -67,6 +69,7 @@ import * as Joi from 'joi';
     UsersModule,
     RestaurantsModule,
     AuthModule,
+    OrdersModule,
   ],
   controllers: [],
   providers: [],

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -1,0 +1,63 @@
+import { Restaurant } from './../../restaurants/entities/restaurant.entity';
+import { Dish } from './../../restaurants/entities/dish.entity';
+import { User } from './../../users/entities/user.entity';
+import { CoreEntity } from './../../common/entities/core.entity';
+import { IsEnum, IsNumber } from 'class-validator';
+import {
+  Field,
+  ObjectType,
+  InputType,
+  registerEnumType,
+  Float,
+} from '@nestjs/graphql';
+import { Entity, Column, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+
+export enum OrderStatus {
+  PENDING = 'PENDING',
+  COOKING = 'COOKING',
+  PICKED_UP = 'PICKED_UP',
+  DELIVERED = 'DELIVERED',
+}
+
+registerEnumType(OrderStatus, { name: 'OrderStatus' });
+
+@InputType('RestaurantInputType', { isAbstract: true })
+@ObjectType()
+@Entity()
+export class Order extends CoreEntity {
+  @Field(() => User, { nullable: true })
+  @ManyToOne(() => User, (user) => user.orders, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  customer?: User;
+
+  @Field(() => User, { nullable: true })
+  @ManyToOne(() => User, (user) => user.rides, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  driver?: User;
+
+  @Field(() => Restaurant)
+  @ManyToOne(() => Restaurant, (restaurant) => restaurant.orders, {
+    onDelete: 'SET NULL',
+    nullable: true,
+  })
+  restaurant: Restaurant;
+
+  @Field(() => [Dish])
+  @ManyToMany(() => Dish)
+  @JoinTable()
+  dishes: Dish[];
+
+  @Column()
+  @Field(() => Float)
+  @IsNumber()
+  total: number;
+
+  @Column({ type: 'enum', enum: OrderStatus })
+  @Field(() => OrderStatus)
+  @IsEnum(OrderStatus)
+  status: OrderStatus;
+}

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -1,0 +1,4 @@
+import { Module } from '@nestjs/common';
+
+@Module({})
+export class OrdersModule {}

--- a/src/restaurants/entities/restaurant.entity.ts
+++ b/src/restaurants/entities/restaurant.entity.ts
@@ -1,3 +1,4 @@
+import { Order } from './../../orders/entities/order.entity';
 import { Dish } from './dish.entity';
 import { User } from './../../users/entities/user.entity';
 import { Category } from './category.entity';
@@ -37,10 +38,14 @@ export class Restaurant extends CoreEntity {
   @ManyToOne(() => User, (user) => user.restaurants, { onDelete: 'CASCADE' })
   owner: User;
 
-  @RelationId((restaurant: Restaurant) => restaurant.owner)
-  ownerId: number;
-
   @Field(() => [Dish])
   @OneToMany(() => Dish, (dish) => dish.restaurant)
   menu: Dish[];
+
+  @Field(() => [Order])
+  @OneToMany(() => Order, (order) => order.restaurant)
+  orders: Order[];
+
+  @RelationId((restaurant: Restaurant) => restaurant.owner)
+  ownerId: number;
 }

--- a/src/restaurants/restaurants.module.ts
+++ b/src/restaurants/restaurants.module.ts
@@ -1,3 +1,4 @@
+import { Order } from './../orders/entities/order.entity';
 import { Dish } from './entities/dish.entity';
 import { CategoryRepository } from './repositories/category.repository';
 import { RestaurantService } from './restaurants.service';
@@ -11,7 +12,9 @@ import {
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Restaurant, CategoryRepository, Dish])],
+  imports: [
+    TypeOrmModule.forFeature([Restaurant, CategoryRepository, Dish, Order]),
+  ],
   providers: [
     RestaurantResolver,
     RestaurantService,

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Order } from './../../orders/entities/order.entity';
 import { Restaurant } from './../../restaurants/entities/restaurant.entity';
 import {
   ObjectType,
@@ -45,6 +46,14 @@ export class User extends CoreEntity {
   @OneToMany(() => Restaurant, (restaurant) => restaurant.owner)
   @Field(() => [Restaurant])
   restaurants: Restaurant[];
+
+  @OneToMany(() => Order, (order) => order.customer)
+  @Field(() => [Order])
+  orders: Order[];
+
+  @OneToMany(() => Order, (order) => order.driver)
+  @Field(() => [Order])
+  rides: Order[];
 
   @BeforeInsert()
   @BeforeUpdate()

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,3 +1,4 @@
+import { Order } from './../orders/entities/order.entity';
 import { Verification } from './entities/verification.entity';
 import { UsersService } from './users.service';
 import { UserResolver } from './users.resolver';
@@ -6,7 +7,7 @@ import { User } from './entities/user.entity';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Verification])],
+  imports: [TypeOrmModule.forFeature([User, Verification, Order])],
   providers: [UserResolver, UsersService],
   exports: [UsersService],
 })


### PR DESCRIPTION
`Order` 엔티티 작성
- `order`와 `customer`는 N:1의 관계를 가진다
- `order`와 `driver`는 N:1의 관계를 가진다
- `order`와 `restaurant`는 N:1의 관계를 가진다
- `order`와 `dishes`는 N:M의 관계를 가진다. 이때 `dish`를 통해 `order`를 알 필요는 없고, `order`를 통해 `dish`를 알야하므로, `JoinTable`은 `order`에 속한다. 