### PR TITLE
[Resolver]getOrders 리졸버 구현

### DIFF
--- a/src/orders/dtos/get-orders.dto.ts
+++ b/src/orders/dtos/get-orders.dto.ts
@@ -1,0 +1,15 @@
+import { Field, InputType, ObjectType } from '@nestjs/graphql';
+import { CoreOutput } from 'src/common/dtos/output.dto';
+import { Order, OrderStatus } from '../entities/order.entity';
+
+@InputType()
+export class GetOrdersInput {
+  @Field(() => OrderStatus, { nullable: true })
+  status?: OrderStatus;
+}
+
+@ObjectType()
+export class GetOrdersOutput extends CoreOutput {
+  @Field(() => [Order], { nullable: true })
+  orders?: Order[];
+}

--- a/src/orders/orders.resolver.ts
+++ b/src/orders/orders.resolver.ts
@@ -1,3 +1,4 @@
+import { GetOrdersInput, GetOrdersOutput } from './dtos/get-orders.dto';
 import { CreateOrderOutput, CreateOrderInput } from './dtos/create-order.dto';
 import { Args, Mutation, Resolver } from '@nestjs/graphql';
 import { AuthUser } from 'src/auth/auth-user.decorator';
@@ -17,5 +18,14 @@ export class OrderResolver {
     @Args('input') createOrderInput: CreateOrderInput,
   ): Promise<CreateOrderOutput> {
     return this.orderService.createOrder(customer, createOrderInput);
+  }
+
+  @Mutation(() => GetOrdersOutput)
+  @Role(['Any'])
+  async getOrders(
+    @AuthUser() user: User,
+    @Args('input') getOrdersInput: GetOrdersInput,
+  ): Promise<GetOrdersOutput> {
+    return this.orderService.getOrders(user, getOrdersInput);
   }
 }


### PR DESCRIPTION
`Role` 데코레이터 상에서 로그인한 누구나 접근해서 현재 주문을 가져올 수 있는 `getOrders` 뮤테이션 구현
- 서비스 클래스 내부에서 user의 `role`에 따라 각각 적합한 형태의 `orders` 를 찾아서 반환해준다. 
- 현재 if-else 문으로 구분. 추후 리팩토링 필요