### PR TITLE
[Resolver]getOrder & EditOrder 리졸버 구현

### DIFF
--- a/src/orders/dtos/edit-order.dto.ts
+++ b/src/orders/dtos/edit-order.dto.ts
@@ -1,0 +1,9 @@
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { Order } from './../entities/order.entity';
+import { InputType, ObjectType, PickType } from '@nestjs/graphql';
+
+@InputType()
+export class EditOrderInput extends PickType(Order, ['id', 'status']) {}
+
+@ObjectType()
+export class EditOrderOutput extends CoreOutput {}

--- a/src/orders/dtos/get-order.dto.ts
+++ b/src/orders/dtos/get-order.dto.ts
@@ -1,0 +1,12 @@
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { Order } from './../entities/order.entity';
+import { Field, InputType, ObjectType, PickType } from '@nestjs/graphql';
+
+@InputType()
+export class GetOrderInput extends PickType(Order, ['id']) {}
+
+@ObjectType()
+export class GetOrderOutput extends CoreOutput {
+  @Field(() => Order, { nullable: true })
+  order?: Order;
+}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -11,11 +11,19 @@ import {
   registerEnumType,
   Float,
 } from '@nestjs/graphql';
-import { Entity, Column, ManyToOne, ManyToMany, JoinTable } from 'typeorm';
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  ManyToMany,
+  JoinTable,
+  RelationId,
+} from 'typeorm';
 
 export enum OrderStatus {
   PENDING = 'PENDING',
   COOKING = 'COOKING',
+  COOKED = 'COOKED',
   PICKED_UP = 'PICKED_UP',
   DELIVERED = 'DELIVERED',
 }
@@ -33,12 +41,18 @@ export class Order extends CoreEntity {
   })
   customer?: User;
 
+  @RelationId((order: Order) => order.customer)
+  customerId: number;
+
   @Field(() => User, { nullable: true })
   @ManyToOne(() => User, (user) => user.rides, {
     onDelete: 'SET NULL',
     nullable: true,
   })
   driver?: User;
+
+  @RelationId((order: Order) => order.driver)
+  driverId: number;
 
   @Field(() => Restaurant, { nullable: true })
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.orders, {

--- a/src/orders/orders.resolver.ts
+++ b/src/orders/orders.resolver.ts
@@ -1,6 +1,8 @@
+import { EditOrderOutput, EditOrderInput } from './dtos/edit-order.dto';
+import { GetOrderOutput, GetOrderInput } from './dtos/get-order.dto';
 import { GetOrdersInput, GetOrdersOutput } from './dtos/get-orders.dto';
 import { CreateOrderOutput, CreateOrderInput } from './dtos/create-order.dto';
-import { Args, Mutation, Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Resolver, Query } from '@nestjs/graphql';
 import { AuthUser } from 'src/auth/auth-user.decorator';
 import { Role } from 'src/auth/role.decorator';
 import { User } from 'src/users/entities/user.entity';
@@ -20,12 +22,30 @@ export class OrderResolver {
     return this.orderService.createOrder(customer, createOrderInput);
   }
 
-  @Mutation(() => GetOrdersOutput)
+  @Query(() => GetOrdersOutput)
   @Role(['Any'])
   async getOrders(
     @AuthUser() user: User,
     @Args('input') getOrdersInput: GetOrdersInput,
   ): Promise<GetOrdersOutput> {
     return this.orderService.getOrders(user, getOrdersInput);
+  }
+
+  @Query(() => GetOrderOutput)
+  @Role(['Any'])
+  async getOrder(
+    @AuthUser() user: User,
+    @Args('inout') getOrderInput: GetOrderInput,
+  ): Promise<GetOrderOutput> {
+    return this.orderService.getOrder(user, getOrderInput);
+  }
+
+  @Mutation(() => EditOrderOutput)
+  @Role(['Any'])
+  async editOrder(
+    @AuthUser() user: User,
+    @Args('input') editOrderInput: EditOrderInput,
+  ): Promise<EditOrderOutput> {
+    return this.orderService.editOrder(user, editOrderInput);
   }
 }


### PR DESCRIPTION
`getOrder` : `user` 의 역할별로 각각에 맞는 주문을 확인할 수 있는 리졸버. 예를 들어 손님이라면 자신이 주문한 order를 조회, 음식점 주인은 자신이 소유한 `restaurant`에 들어온 주문을 확인할 수 있다.

`EditOrder` : 단계에 따라 `OrderStatus`를 변경할 수 있는 뮤테이션