### PR TITLE
[Subscription] 실시간 주문 정보 업데이트를 역할별로 받기 위한 Subscription 작성

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from './common/common.module';
 import { OrderItem } from './orders/entities/order-item.entity';
 import { Order } from './orders/entities/order.entity';
 import { Dish } from './restaurants/entities/dish.entity';
@@ -84,6 +85,7 @@ import * as Joi from 'joi';
     RestaurantsModule,
     AuthModule,
     OrdersModule,
+    CommonModule,
   ],
   controllers: [],
   providers: [],

--- a/src/common/common.constants.ts
+++ b/src/common/common.constants.ts
@@ -3,3 +3,4 @@ export const PUB_SUB = 'PUB_SUB';
 
 export const NEW_PENDING_ORDER = 'NEW_PENDING_ORDER';
 export const NEW_COOKED_ORDER = 'NEW_COOKED_ORDER';
+export const NEW_ORDER_UPDATE = 'NEW_ORDER_UPDATE';

--- a/src/common/common.constants.ts
+++ b/src/common/common.constants.ts
@@ -2,3 +2,4 @@ export const CONFIG_OPTIONS = 'CONFIG_OPTIONS';
 export const PUB_SUB = 'PUB_SUB';
 
 export const NEW_PENDING_ORDER = 'NEW_PENDING_ORDER';
+export const NEW_COOKED_ORDER = 'NEW_COOKED_ORDER';

--- a/src/common/common.constants.ts
+++ b/src/common/common.constants.ts
@@ -1,1 +1,4 @@
 export const CONFIG_OPTIONS = 'CONFIG_OPTIONS';
+export const PUB_SUB = 'PUB_SUB';
+
+export const NEW_PENDING_ORDER = 'NEW_PENDING_ORDER';

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,4 +1,16 @@
-import { Module } from '@nestjs/common';
+import { Module, Global } from '@nestjs/common';
+import { PubSub } from 'graphql-subscriptions';
+import { PUB_SUB } from './common.constants';
 
-@Module({})
+const pubsub = new PubSub();
+@Global()
+@Module({
+  providers: [
+    {
+      provide: PUB_SUB,
+      useValue: pubsub,
+    },
+  ],
+  exports: [PUB_SUB],
+})
 export class CommonModule {}

--- a/src/orders/dtos/order-updates.dto.ts
+++ b/src/orders/dtos/order-updates.dto.ts
@@ -1,0 +1,5 @@
+import { Order } from './../entities/order.entity';
+import { InputType, PickType } from '@nestjs/graphql';
+
+@InputType()
+export class OrderUpdatesInput extends PickType(Order, ['id']) {}

--- a/src/orders/dtos/take-order.dto.ts
+++ b/src/orders/dtos/take-order.dto.ts
@@ -1,0 +1,9 @@
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { Order } from './../entities/order.entity';
+import { InputType, ObjectType, PickType } from '@nestjs/graphql';
+
+@InputType()
+export class TakeOrderInput extends PickType(Order, ['id']) {}
+
+@ObjectType()
+export class TakeOrderOutput extends CoreOutput {}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -38,6 +38,7 @@ export class Order extends CoreEntity {
   @ManyToOne(() => User, (user) => user.orders, {
     onDelete: 'SET NULL',
     nullable: true,
+    eager: true,
   })
   customer?: User;
 
@@ -48,6 +49,7 @@ export class Order extends CoreEntity {
   @ManyToOne(() => User, (user) => user.rides, {
     onDelete: 'SET NULL',
     nullable: true,
+    eager: true,
   })
   driver?: User;
 
@@ -58,11 +60,12 @@ export class Order extends CoreEntity {
   @ManyToOne(() => Restaurant, (restaurant) => restaurant.orders, {
     onDelete: 'SET NULL',
     nullable: true,
+    eager: true,
   })
   restaurant?: Restaurant;
 
   @Field(() => [OrderItem])
-  @ManyToMany(() => OrderItem)
+  @ManyToMany(() => OrderItem, { eager: true })
   @JoinTable()
   items: OrderItem[];
 

--- a/src/orders/orders.resolver.ts
+++ b/src/orders/orders.resolver.ts
@@ -1,3 +1,4 @@
+import { NEW_COOKED_ORDER } from './../common/common.constants';
 import { PubSub } from 'graphql-subscriptions';
 import { EditOrderOutput, EditOrderInput } from './dtos/edit-order.dto';
 import { GetOrderOutput, GetOrderInput } from './dtos/get-order.dto';
@@ -41,7 +42,7 @@ export class OrderResolver {
   @Role(['Any'])
   async getOrder(
     @AuthUser() user: User,
-    @Args('inout') getOrderInput: GetOrderInput,
+    @Args('input') getOrderInput: GetOrderInput,
   ): Promise<GetOrderOutput> {
     return this.orderService.getOrder(user, getOrderInput);
   }
@@ -64,5 +65,11 @@ export class OrderResolver {
   @Role(['OWNER'])
   pendingOrders() {
     return this.pubsub.asyncIterator(NEW_PENDING_ORDER);
+  }
+
+  @Subscription(() => Order)
+  @Role(['DELIVERY'])
+  cookedOrder() {
+    return this.pubsub.asyncIterator(NEW_COOKED_ORDER);
   }
 }

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,3 +1,4 @@
+import { NEW_COOKED_ORDER } from './../common/common.constants';
 import { EditOrderInput, EditOrderOutput } from './dtos/edit-order.dto';
 import { GetOrderInput, GetOrderOutput } from './dtos/get-order.dto';
 import { GetOrdersInput, GetOrdersOutput } from './dtos/get-orders.dto';
@@ -244,12 +245,18 @@ export class OrderService {
         };
       }
 
-      await this.orderRepository.save([
-        {
-          id: orderId,
-          status,
-        },
-      ]);
+      await this.orderRepository.save({
+        id: orderId,
+        status,
+      });
+
+      if (user.role === UserRole.OWNER) {
+        if (status === OrderStatus.COOKED) {
+          await this.pubsub.publish(NEW_COOKED_ORDER, {
+            cookedOrders: { ...order, status },
+          });
+        }
+      }
       return {
         isSucceeded: true,
       };


### PR DESCRIPTION
Orders Subscription 내용

- `Pending Orders`(sub: newOrder) (trigger: createOrder(newOrder))
 - 레스토랑 오너는 대기 중인 주문을 구독할 수 있다. 이 구독에서는 새로운 주문이 만들어지는 `createOrder` 이벤트에 의해 트리거된다.
- `Order Status`(Customer독, Delivery, Owner)  (sub: orderUpdate) (trigger: editOrder(orderUpdate))
 - 주문과 관련된 모든 사람은 주문의 업데이트 상황을 구독할 수 있다. 이 구독은 `editOrder` 이벤트에 의해 트리거 된다.
- `Pending Pickup Order` (Delivery) (sub: OrderUpdate) (tigger: editOrder(OrderUpdate))
 - 배달원이 새로 생겨나는 모든 주문을 구독하고 있다가, 특정 주문을 픽업하면 주문 상태를 업데이트 할 수 있다. 